### PR TITLE
Add branch and commit message policy

### DIFF
--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+regex='(.*:) (:*:.*:) (.*)'
+commit_message=$(cat "${1}")
+
+if ! [[ $commit_message =~ $regex ]]; then
+   printf "[pre-commit-hook] The commit message '$commit_message' does not follow the conventional commits specification. \nSee here for more info: https://conventionalcommits.org/"
+   exit 1
+else
+   echo "Commit message looks good"
+fi

--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -6,6 +6,4 @@ commit_message=$(cat "${1}")
 if ! [[ $commit_message =~ $regex ]]; then
    printf "[pre-commit-hook] The commit message '$commit_message' does not follow the conventional commits specification. \nSee here for more info: https://conventionalcommits.org/"
    exit 1
-else
-   echo "Commit message looks good"
 fi

--- a/.github/hooks/post-checkout
+++ b/.github/hooks/post-checkout
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+regex="(feature|bug)(\/)([0-9]{1,})(-)(.*)"
+branch=$(echo $(git rev-parse --abbrev-ref HEAD))
+
+if ! [[ $branch =~ $regex ]]; then
+   printf "[post-checkout] Your branch name does not follow the expected convention.\nExpected pattern is: feature/213-create-million-dollar-app\nOr see regex: $regex\nPlease rename your branch accordingly."
+   exit 1
+fi


### PR DESCRIPTION
This pull request adds two git hooks to validate the name of an branch and the commit message.

To achieve this, it was required to:
- Define and create the convention policy
- Create a hooks directory with two hooks...
  - commit-msg: For validating the commit message which follows the [conventional commits specification](https://conventionalcommits.org)
  - post-checkout: For validating the branch name. This hook will run on checkout and branch creation but will only work locally.