### PR TITLE
Fix mssql permission issue and add firebase logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .env
-config/firebase/ui-debug.log
+config/firebase/*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - ${DB_PORT}:1433
     volumes:
-      - db:/var/opt/mssql/data
+      - db:/var/opt/mssql
     environment:
       SA_PASSWORD: ${DB_SA_PASSWORD}
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
As the title suggests this PR adds the local firebase emulator logs to the .gitignore and also fixes the issue when the mssql container would not start due to lack of permissions.
See this issue for more info: See: https://github.com/microsoft/mssql-docker/issues/542#issuecomment-1129427855